### PR TITLE
Allow MatingActivation Screen on clients

### DIFF
--- a/src/main/java/org/terasology/wildAnimalsGenome/AnimalMatingSystem.java
+++ b/src/main/java/org/terasology/wildAnimalsGenome/AnimalMatingSystem.java
@@ -32,11 +32,13 @@ import org.terasology.genome.events.OnBreed;
 import org.terasology.logic.behavior.BehaviorComponent;
 import org.terasology.logic.behavior.asset.BehaviorTree;
 import org.terasology.logic.characters.AliveCharacterComponent;
+import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.CharacterTeleportEvent;
 import org.terasology.logic.common.ActivateEvent;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.DelayedActionTriggeredEvent;
 import org.terasology.logic.location.LocationComponent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.minion.move.MinionMoveComponent;
 import org.terasology.registry.In;
@@ -62,6 +64,8 @@ public class AnimalMatingSystem extends BaseComponentSystem implements UpdateSub
     private NUIManager nuiManager;
     @In
     private AssetManager assetManager;
+    @In
+    private LocalPlayer localPlayer;
 
     /**
      * Delay between consecutive searches for a mate.
@@ -243,13 +247,23 @@ public class AnimalMatingSystem extends BaseComponentSystem implements UpdateSub
     }
 
     /**
-     * Opens the {@link AnimalInteractionScreen} on activating an animal.
+     * Sends a {@link ActivateMatingScreenEvent} to the client activating an animal
      */
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH, components = {WildAnimalComponent.class})
     public void onFrob(ActivateEvent event, EntityRef entityRef) {
+        event.getInstigator().send(new ActivateMatingScreenEvent(entityRef));
         event.consume();
-        AnimalInteractionScreen animalInteractionScreen = nuiManager.pushScreen("WildAnimalsGenome:animalInteractionScreen", AnimalInteractionScreen.class);
-        animalInteractionScreen.setAnimalEntity(entityRef);
+    }
+
+    /**
+     * Opens the {@link AnimalInteractionScreen} on activating an animal.
+     */
+    @ReceiveEvent
+    public void onActivateAnimalInteractionScreenEvent(ActivateMatingScreenEvent event, EntityRef entity, CharacterComponent component) {
+        if (entity.equals(localPlayer.getCharacterEntity())) {
+            AnimalInteractionScreen animalInteractionScreen = nuiManager.pushScreen("WildAnimalsGenome:animalInteractionScreen", AnimalInteractionScreen.class);
+            animalInteractionScreen.setAnimalEntity(event.getTargetEntity());
+        }
     }
 
     /**

--- a/src/main/java/org/terasology/wildAnimalsGenome/event/ActivateMatingScreenEvent.java
+++ b/src/main/java/org/terasology/wildAnimalsGenome/event/ActivateMatingScreenEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.wildAnimalsGenome.event;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.Event;
+import org.terasology.network.OwnerEvent;
+
+@OwnerEvent
+public class ActivateMatingScreenEvent implements Event {
+    private EntityRef targetEntity;
+
+    public ActivateMatingScreenEvent() {}
+
+    public ActivateMatingScreenEvent(EntityRef targetEntity) {
+        this.targetEntity = targetEntity;
+    }
+
+    public EntityRef getTargetEntity() {
+        return targetEntity;
+    }
+}


### PR DESCRIPTION
Allows for the MatingActivationScreen to be seen by clients when interacting with an animal. Currently the actual screen does not function properly. (Information about this is relayed in the slack #content channel)