### PR TITLE
Crash fix: prevent issue when mating is interrupted

### DIFF
--- a/src/main/java/org/terasology/wildAnimalsGenome/AnimalMatingAuthoritySystem.java
+++ b/src/main/java/org/terasology/wildAnimalsGenome/AnimalMatingAuthoritySystem.java
@@ -86,7 +86,7 @@ public class AnimalMatingAuthoritySystem extends BaseComponentSystem implements 
         BehaviorTree mateBT = assetManager.getAsset("WildAnimalsGenome:mate", BehaviorTree.class).get();
         for (EntityRef entityRef : entityManager.getEntitiesWith(MatingBehaviorComponent.class)) {
             MatingComponent matingComponent = entityRef.getComponent(MatingComponent.class);
-            if (entityRef.getComponent(BehaviorComponent.class).tree != mateBT) {
+            if (entityRef.hasComponent(BehaviorComponent.class) && entityRef.getComponent(BehaviorComponent.class).tree != mateBT) {
                 if (matingComponent.matingEntity != EntityRef.NULL && matingComponent.matingEntity.hasComponent(MatingBehaviorComponent.class)) {
                     matingComponent.matingEntity.removeComponent(MatingBehaviorComponent.class);
                     matingComponent.matingEntity.send(new UpdateBehaviorEvent());


### PR DESCRIPTION
Such as by killing a deer presently in the mood faster than it can change its mood

To reproduce (before this commit): get a *fast* way to kill a deer, such as the `give mrbasack` axe (insta-kills). `spawnPrefab deer` twice and get them in the mood by activating mating for both. Now kill one of them before they consummate their desires. NPE on the line this PR changes.

This does *not* happen if you kill a deer more slowly as they'll switch into "flee" mood instead, meaning the mating system doesn't trigger fast enough to consider the now *deerly* departed.

Merging this immediately for Alpha 8 :-) I haven't checked on other conditions but this fix seems safe. There are some Checkstyle violations in the file I left alone, and other places could be likewise hardened. Leaving that for you sometime @arpan98 :D