### PR TITLE
refactor: Adjust for Behaviors#89

### DIFF
--- a/assets/behaviors/mate.behavior
+++ b/assets/behaviors/mate.behavior
@@ -3,7 +3,6 @@
     {
       sequence: [
         set_mating_target_block,
-        ensure_target_present,
         move_to
       ]
     }

--- a/src/main/java/org/terasology/wildAnimalsGenome/BehaviorNode/SetMatingTargetBlockNode.java
+++ b/src/main/java/org/terasology/wildAnimalsGenome/BehaviorNode/SetMatingTargetBlockNode.java
@@ -3,6 +3,7 @@
 package org.terasology.wildAnimalsGenome.BehaviorNode;
 
 import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
@@ -12,8 +13,8 @@ import org.terasology.module.behaviors.components.MinionMoveComponent;
 import org.terasology.wildAnimalsGenome.component.MatingComponent;
 
 /**
- * Updates the target field in the {@link MinionMoveComponent} of the animal's mate with the target set in the current
- * animal's {@link MinionMoveComponent}
+ * Updates the target field in the {@link MinionMoveComponent} of the animal's mate with the target set in the current animal's {@link
+ * MinionMoveComponent}
  */
 @BehaviorAction(name = "set_mating_target_block")
 public class SetMatingTargetBlockNode extends BaseAction {
@@ -26,10 +27,9 @@ public class SetMatingTargetBlockNode extends BaseAction {
         MinionMoveComponent actorMoveComponent = actor.getComponent(MinionMoveComponent.class);
         MinionMoveComponent matingEntityMoveComponent = matingEntity.getComponent(MinionMoveComponent.class);
 
-
         if (actorMoveComponent.target != null) {
-            Vector3f actorTarget = actorMoveComponent.target;
-            matingEntityMoveComponent.target = new Vector3f(actorTarget);
+            Vector3i actorTarget = actorMoveComponent.target;
+            matingEntityMoveComponent.target = new Vector3i(actorTarget);
             matingEntityMoveComponent.target.add(1, 0, 0);
             matingEntity.saveComponent(matingEntityMoveComponent);
 


### PR DESCRIPTION
Adjust for https://github.com/Terasology/Behaviors/pull/89

A few components and systems have changed due to the switch from Pathfinding to FlexiblePathfinding.

This PR adjusts the breaking pieces of code to the best of my knowledge. Typical changes for this migration are:

- `MinionMoveComponent#target` is now a `Vector3i` and no longer a `Vector3f` (fixed by rounding)
- `MinionMoveComponent#type` was removed (no longer required, just remove references)
